### PR TITLE
DOKUWIKI-6 : Import Dokuwiki starts, but crashes after a few Seconds …

### DIFF
--- a/dokuwiki-text/src/test/resources/dokuwikitext/dokuwiki-meta-missing.test
+++ b/dokuwiki-text/src/test/resources/dokuwikitext/dokuwiki-meta-missing.test
@@ -863,7 +863,7 @@ Notes:
 
 /**
 
-*
+* 
 ** Customization of the english language file
 ** Copy only the strings that needs to be modified
 


### PR DESCRIPTION
…with class java.lang.ArrayIndexOutOfBoundsException.

* Fixed test case. ( dokuwiki-meta-missing.test ).