### PR TITLE
DOKUWIKI-7 : FileNotFoundException: File '/usr/local/tomcat/temp/dokuwiki5619913892744179732/conf/users.auth.php' does not exist  DOKUWIKI-8 : OOM when importing a tgz on XWiki 10.3  * FileUtils.copyToFile was closing the archiveInputStream after copying file. * Added Proxy stream that prevents the archiveInputStream from being closed.

### DIFF
--- a/dokuwiki-text/src/main/java/org/xwiki/contrib/dokuwiki/text/internal/input/DokuWikiInputFilterStream.java
+++ b/dokuwiki-text/src/main/java/org/xwiki/contrib/dokuwiki/text/internal/input/DokuWikiInputFilterStream.java
@@ -491,6 +491,9 @@ public class DokuWikiInputFilterStream extends AbstractBeanInputFilterStream<Dok
                 /**
                  * FileUtils.copyToFile closes the input stream, so,
                  * Proxy stream prevents the archiveInputStream from being closed.
+                 * This is a workaround for a bug at commons-io side.
+                 * (https://issues.apache.org/jira/browse/IO-554).
+                 * If fixed on commons-io side, pass archiveInputStream to FileUtils.copyToFile() directly.
                  */
                 CloseShieldInputStream proxy = new CloseShieldInputStream(archiveInputStream);
                 FileUtils.copyToFile(proxy, new File(folderToSave, entryName));

--- a/dokuwiki-text/src/main/java/org/xwiki/contrib/dokuwiki/text/internal/input/DokuWikiInputFilterStream.java
+++ b/dokuwiki-text/src/main/java/org/xwiki/contrib/dokuwiki/text/internal/input/DokuWikiInputFilterStream.java
@@ -44,6 +44,7 @@ import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.CloseShieldInputStream;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
@@ -486,9 +487,13 @@ public class DokuWikiInputFilterStream extends AbstractBeanInputFilterStream<Dok
             entryName = entryName.replaceFirst(KEY_DOKUWIKI + System.getProperty(KEY_FILE_SEPERATOR), "");
         }
         if (!archiveEntry.isDirectory()) {
-
             try {
-                FileUtils.copyToFile(archiveInputStream, new File(folderToSave, entryName));
+                /**
+                 * FileUtils.copyToFile closes the input stream, so,
+                 * Proxy stream prevents the archiveInputStream from being closed.
+                 */
+                CloseShieldInputStream proxy = new CloseShieldInputStream(archiveInputStream);
+                FileUtils.copyToFile(proxy, new File(folderToSave, entryName));
             } catch (IOException e) {
                 this.logger.error("failed to write stream to file", e);
             }


### PR DESCRIPTION
DOKUWIKI-7 : FileNotFoundException: File '/usr/local/tomcat/temp/dokuwiki5619913892744179732/conf/users.auth.php' does not exist

DOKUWIKI-8 : OOM when importing a tgz on XWiki 10.3

* FileUtils.copyToFile was closing the archiveInputStream after copying file.
* Added Proxy stream that prevents the archiveInputStream from being closed.
* This is a workaround for a bug at commons-io side. (https://issues.apache.org/jira/browse/IO-554) and might not be needed in future if fixed at commons-io side.